### PR TITLE
Fixed a bug - CvrClient is not using given httpClient for anything other than token provider.

### DIFF
--- a/src/Kmd.Logic.Cvr.Client/CvrClient.cs
+++ b/src/Kmd.Logic.Cvr.Client/CvrClient.cs
@@ -321,7 +321,7 @@ namespace Kmd.Logic.Cvr.Client
 
             var tokenProvider = this._tokenProviderFactory.GetProvider(this._httpClient);
 
-            this._internalClient = new InternalClient(new TokenCredentials(tokenProvider))
+            this._internalClient = new InternalClient(new TokenCredentials(tokenProvider), this._httpClient, false)
             {
                 BaseUri = this._options.CvrServiceUri,
             };


### PR DESCRIPTION
The current **CvrClient** implementation ignores **HttpClient** from the constructor for anything other than **TokenProvider**.